### PR TITLE
Changing HTTP headers to lower case

### DIFF
--- a/src/main/java/com/epam/reportportal/restendpoint/http/HttpClientRestEndpoint.java
+++ b/src/main/java/com/epam/reportportal/restendpoint/http/HttpClientRestEndpoint.java
@@ -499,7 +499,7 @@ public class HttpClientRestEndpoint implements RestEndpoint {
 					Header[] allHeaders = response.getAllHeaders();
 					ImmutableMultimap.Builder<String, String> headersBuilder = ImmutableMultimap.builder();
 					for (Header header : allHeaders) {
-						headersBuilder.put(header.getName(), null == header.getValue() ? "" : header.getValue());
+						headersBuilder.put(header.getName().toLowerCase(), null == header.getValue() ? "" : header.getValue());
 					}
 
 					/* convert entire response */


### PR DESCRIPTION
HTTP header labels are case insensitive. Changing to save as lower case.
Fix for: https://github.com/reportportal/client-java/issues/28#issue-435878217